### PR TITLE
Add GuixRUs Channel Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ cd aparte
 guix package -f guix.scm
 ```
 
+Package with GuixRUS
+
+The [GuixRUs](https://git.sr.ht/~whereiseveryone/guixrus) channel also provides `aparte`.
+
+After [subscribing](https://git.sr.ht/~whereiseveryone/guixrus#subscribing) to `GuixRUs` by adding the channel entry to your [channels.scm](https://guix.gnu.org/manual/en/html_node/Using-a-Custom-Guix-Channel.html), run the following two commands:
+
+  ```
+  guix pull
+  guix install aparte
+  ```
+
 Package for Archlinux
 ---------------------
 


### PR DESCRIPTION
Hi,

I added aparte to a pre-release channel called GuixRUS that I maintain with some other guix upstream contributors including southerntofu.

All commits are gpg signed by the maintainers.

We'll be providing binaries, also called [substitutes](https://guix.gnu.org/manual/en/html_node/Substitutes.html)  in guix jargon,  to the public (TBA).

For now, you can subscribe to the channel and run `guix install aparte`.

The package definition will be pulled from our source and built on your local machine.