### PR TITLE
Fix compilation errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ backtrace = "^0.3"
 futures = "^0.3"
 tokio = { version = "^1.0", features = ["full"] }
 tokio-xmpp = "^3.0"
-xmpp-parsers = "^0.18"
+xmpp-parsers = "^0.19"
 rpassword = "^3.0"
 uuid = { version = "^0.7", features = ["v4"]  }
 termion = "1.5"

--- a/src/mods/bookmarks.rs
+++ b/src/mods/bookmarks.rs
@@ -380,7 +380,7 @@ impl Bookmarks2 {
                     name: bookmark.name,
                     nick: bookmark.nick,
                     password: None,
-                    extensions: Some(vec![]),
+                    extensions: Vec::new(),
                 }
                 .into(),
             ),


### PR DESCRIPTION
The develop branch doesn't compile anymore because:

- xmpp-parsers doesn't compile (solved by upgrading)
- bookmarks2::Conference.extensions expects Vec, not Option<Vec>