### PR TITLE
Add basedir argument and help message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,13 +33,48 @@ mod word;
 
 use crate::core::Aparte;
 
-fn main() {
-    let data_dir = dirs::data_dir().unwrap();
-    let aparte_data = data_dir.join("aparte");
+fn help() {
+    println!("aparte [BASEDIR]");
+    println!("----------------");
+    println!("  -h|--help|help - Display this help message");
+    println!("  BASEDIR: Directory for config and logs (defaults to ~/.config/aparte and ~/.local/share/aparte)");
+}
 
-    if let Err(e) = std::fs::create_dir_all(&aparte_data) {
-        panic!("Cannot create aparte data dir: {}", e);
-    }
+fn main() {
+    let mut args = std::env::args();
+
+    let basedir = if let Some(arg) = args.nth(1) {
+        if arg == "help" || arg == "--help" || arg == "-h" {
+            help();
+            return;
+        } else {
+            Some(arg)
+        }
+    } else {
+        None
+    };
+
+    let (aparte_conf, aparte_data) = if let Some(dir) = basedir {
+        // Explicit basedir from arg 1
+        let dir = std::path::PathBuf::from(&dir);
+        if ! dir.is_dir() {
+            panic!("Provided basedir {} is not a folder", dir.display());
+        }
+        (dir.clone(), dir.clone())
+    } else {
+        // Default XDG basedirs (~/.config/aparte and ~/.local/share/aparte)
+        let (aparte_conf, aparte_data) = (dirs::config_dir().unwrap().join("aparte"), dirs::data_dir().unwrap().join("aparte"));
+
+        if let Err(e) = std::fs::create_dir_all(&aparte_data) {
+            panic!("Cannot create aparte data dir: {}", e);
+        }
+
+        if let Err(e) = std::fs::create_dir_all(&aparte_conf) {
+            panic!("Cannot create aparte data dir: {}", e);
+        }
+
+        (aparte_conf, aparte_data)
+    };
 
     let file_writer = flexi_logger::writers::FileLogWriter::builder()
         .directory(aparte_data)
@@ -50,13 +85,6 @@ fn main() {
     let logger = flexi_logger::Logger::with_env_or_str("info").log_target(log_target);
     if let Err(e) = logger.start() {
         panic!("Cannot start logger: {}", e);
-    }
-
-    let conf_dir = dirs::config_dir().unwrap();
-    let aparte_conf = conf_dir.join("aparte");
-
-    if let Err(e) = std::fs::create_dir_all(&aparte_conf) {
-        panic!("Cannot create aparte data dir: {}", e);
     }
 
     let config = aparte_conf.join("config.toml");


### PR DESCRIPTION
I want to run several aparte from same user account, but in different basedir. I added an optional first arg for a basedir.

Also added a help message when first arg is --help, help, or -h.