### PR TITLE
Allow to define password in config file (closes #8)

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -19,4 +19,5 @@ pub struct ConnectionInfo {
     pub port: Option<u16>,
     #[serde(default = "false_")]
     pub autoconnect: bool,
+    pub password: Option<String>,
 }


### PR DESCRIPTION
The only thing not clear is [this line](https://github.com/paulfariello/aparte/compare/develop...xmppftw:auto-password?expand=1#diff-7534aab5e9a7a7e69e0ac7e0c3dfe6b38c28ed17ff74289d268738251e1042a3R1082).

I'm not sure if it's because of Password type or if it could be solved with Option<Password> but it seems passing the password from there and/or passing nothing opens a prompt even when the password is set in config.

Ideas?